### PR TITLE
Standard vectors fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ failure = "0.1.3"
 # Note: hashbrown is going to be merged into Rust std
 hashbrown = "0.1.7"
 sha2 = "0.8.0"
-ring = "0.14.3"
+hmac = "0.7.0"
+pbkdf2 = { version = "0.3.0", features=["parallel"], default-features = false }
 rand = "0.6.1"
 once_cell = { version = "0.1.6", features = [ "parking_lot" ] }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -5,11 +5,12 @@
 //! [Seed]: ../seed/struct.Seed.html
 //!
 
-use rand::{ thread_rng, RngCore };
-use ring::{digest, pbkdf2};
+extern crate rand;
+use self::rand::{ thread_rng, RngCore };
 use sha2::Digest;
+use hmac::Hmac;
 
-const PBKDF2_ROUNDS: u32 = 2048;
+const PBKDF2_ROUNDS: usize = 2048;
 const PBKDF2_BYTES: usize = 64;
 
 /// SHA256 helper function, internal to the crate
@@ -35,9 +36,8 @@ pub(crate) fn gen_random_bytes(byte_length: usize) -> Vec<u8> {
 ///
 pub(crate) fn pbkdf2(input: &[u8], salt: &str) -> Vec<u8> {
     let mut seed = vec![0u8; PBKDF2_BYTES];
-    static DIGEST_ALG: &'static digest::Algorithm = &digest::SHA512;
 
-    pbkdf2::derive(DIGEST_ALG, std::num::NonZeroU32::new(PBKDF2_ROUNDS).unwrap(), salt.as_bytes(), input, &mut seed);
+    pbkdf2::pbkdf2::<Hmac<sha2::Sha512>>(input, salt.as_bytes(), PBKDF2_ROUNDS, &mut seed);
 
     seed
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@
 //!
 #[macro_use] extern crate failure;
 #[macro_use] extern crate once_cell;
+extern crate pbkdf2;
 extern crate hashbrown;
 extern crate sha2;
-extern crate ring;
-extern crate rand;
+extern crate hmac;
 
 mod mnemonic;
 mod error;

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -27,7 +27,7 @@ impl Seed {
     /// [Mnemonic]: ./mnemonic/struct.Mnemonic.html
     pub fn new(mnemonic: &Mnemonic, password: &str) -> Self {
         let salt = format!("mnemonic{}", password);
-        let bytes = pbkdf2(mnemonic.entropy(), &salt);
+        let bytes = pbkdf2(mnemonic.phrase().as_bytes(), &salt);
 
         Self {
             bytes,

--- a/tests/standard-vectors.rs
+++ b/tests/standard-vectors.rs
@@ -20,7 +20,7 @@ fn test_seed(phrase: &str, password: &str, expected_seed_hex: &str) {
     let actual_seed_bytes: &[u8] = seed.as_bytes();
     let expected_seed_bytes = hex::decode(expected_seed_hex).unwrap();
 
-    assert!(actual_seed_bytes.eq(expected_seed_bytes.as_slice()), "Wrong seed for '{}'", phrase);
+    assert!(actual_seed_bytes.eq(expected_seed_bytes.as_slice()), "Wrong seed for '{}'\nexp: {:?}\nact: {:?}\n", phrase, expected_seed_hex, hex::encode(actual_seed_bytes));
 }
 
 macro_rules! tests {


### PR DESCRIPTION
Reverts back to using the Rust only fixes and applies the fix @maciejhirz mentioned in infincia/bip39-rs/pull/17 and includes him as a co-author. This way it will be included in your pull request.